### PR TITLE
Fix median computation

### DIFF
--- a/android/WALT/app/src/main/java/org/chromium/latency/walt/AudioFragment.java
+++ b/android/WALT/app/src/main/java/org/chromium/latency/walt/AudioFragment.java
@@ -308,6 +308,9 @@ public class AudioFragment extends Fragment implements View.OnClickListener {
         activity.broadcastManager.unregisterReceiver(onIncomingTimestamp);
         activity.clockManager.logDrift();
 
+        Utils.sort(deltasJ2N);
+        Utils.sort(deltas);
+
         activity.logger.log("deltas: " + deltas.toString());
         activity.logger.log(String.format(
                 "Median Java to native latency %.3f ms\nMedian audio latency %.1f ms",

--- a/android/WALT/app/src/main/java/org/chromium/latency/walt/ScreenResponseFragment.java
+++ b/android/WALT/app/src/main/java/org/chromium/latency/walt/ScreenResponseFragment.java
@@ -188,6 +188,7 @@ public class ScreenResponseFragment extends Fragment implements View.OnClickList
         activity.broadcastManager.unregisterReceiver(onIncomingTimestamp);
 
         // Show deltas and the median
+        Utils.sort(deltas);
         activity.logger.log("deltas: " + deltas.toString());
         activity.logger.log(String.format(
                 "Median latency %.1f ms",

--- a/android/WALT/app/src/main/java/org/chromium/latency/walt/TapLatencyFragment.java
+++ b/android/WALT/app/src/main/java/org/chromium/latency/walt/TapLatencyFragment.java
@@ -226,6 +226,9 @@ public class TapLatencyFragment extends Fragment
             k2c.add((event.createTime - event.kernelTime) / 1000.);
         }
 
+        Utils.sort(p2k);
+        Utils.sort(k2c);
+
         activity.logger.log(p2k.toString());
         activity.logger.log(k2c.toString());
 

--- a/android/WALT/app/src/main/java/org/chromium/latency/walt/Utils.java
+++ b/android/WALT/app/src/main/java/org/chromium/latency/walt/Utils.java
@@ -17,12 +17,17 @@
 package org.chromium.latency.walt;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.InputMismatchException;
 
 /**
  * Kitchen sink for small utility functions
  */
 public class Utils {
+    public static void sort(ArrayList<Double> list) {
+        Collections.sort(list);
+    }
+
     public static double median(ArrayList<Double> lst) {
         int len = lst.size();
         if (len == 0) {


### PR DESCRIPTION
Existing median implementation assumed a given list of samples was sorted, but
the callers did not sort. Added a sort utility function and sorted the samples
before each use of the median function.