### PR TITLE
Ensure only one instance of the main activity exists at once

### DIFF
--- a/android/WALT/app/src/main/AndroidManifest.xml
+++ b/android/WALT/app/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         <activity
             android:name="org.chromium.latency.walt.MainActivity"
             android:label="@string/app_name"
+            android:launchMode="singleTask"
             android:screenOrientation="portrait">
             <meta-data
                 android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED"


### PR DESCRIPTION
This prevents a crash caused by the system starting a second MainActivity
instance in response to a USB device being connected.

Fixes #14.