### PR TITLE
Handle disconnect of WALT better

### DIFF
--- a/android/WALT/app/src/main/java/org/chromium/latency/walt/MainActivity.java
+++ b/android/WALT/app/src/main/java/org/chromium/latency/walt/MainActivity.java
@@ -91,6 +91,7 @@ public class MainActivity extends AppCompatActivity {
         final UsbDevice usbDevice;
         Intent intent = getIntent();
         if (intent != null && intent.getAction().equals(UsbManager.ACTION_USB_DEVICE_ATTACHED)) {
+            setIntent(null); // done with the intent
             usbDevice = intent.getParcelableExtra(UsbManager.EXTRA_DEVICE);
         } else {
             usbDevice = null;


### PR DESCRIPTION
Improvements to handling the WALT device being disconnected, including proper results from isConnected() and avoiding a crash

Fixes #20 