### PR TITLE
Destroy the audio engine and player object when leaving the audio test

### DIFF
--- a/android/WALT/app/src/main/java/org/chromium/latency/walt/AudioFragment.java
+++ b/android/WALT/app/src/main/java/org/chromium/latency/walt/AudioFragment.java
@@ -85,6 +85,12 @@ public class AudioFragment extends Fragment implements View.OnClickListener {
     }
 
     @Override
+    public void onDestroy() {
+        super.onDestroy();
+        mAudioTest.teardown();
+    }
+
+    @Override
     public void onClick(View v) {
         switch (v.getId()) {
             case R.id.button_start_audio_rec:

--- a/android/WALT/app/src/main/java/org/chromium/latency/walt/AudioTest.java
+++ b/android/WALT/app/src/main/java/org/chromium/latency/walt/AudioTest.java
@@ -62,6 +62,7 @@ class AudioTest {
     public static native long playTone();
     // public static native void stopPlaying();
     public static native void createEngine();
+    public static native void destroyEngine();
     public static native void createBufferQueueAudioPlayer(int frameRate, int framesPerBuffer);
 
     public static native void startRecording();
@@ -94,6 +95,10 @@ class AudioTest {
         logger.log("Audio engine created");
     }
 
+    void teardown() {
+        destroyEngine();
+        logger.log("Audio engine destroyed");
+    }
 
     void beginRecordingTest() {
         clockManager.syncClock();

--- a/android/WALT/app/src/main/jni/player.c
+++ b/android/WALT/app/src/main/jni/player.c
@@ -174,6 +174,23 @@ void Java_org_chromium_latency_walt_AudioTest_createEngine(JNIEnv* env, jclass c
     (void)result;
 }
 
+void Java_org_chromium_latency_walt_AudioTest_destroyEngine(JNIEnv *env, jclass clazz)
+{
+    if (bqPlayerObject != NULL) {
+        (*bqPlayerObject)->Destroy(bqPlayerObject);
+        bqPlayerObject = NULL;
+    }
+
+    if (outputMixObject != NULL) {
+        (*outputMixObject)->Destroy(outputMixObject);
+        outputMixObject = NULL;
+    }
+
+    if (engineObject != NULL) {
+        (*engineObject)->Destroy(engineObject);
+        engineObject = NULL;
+    }
+}
 
 // create buffer queue audio player
 void Java_org_chromium_latency_walt_AudioTest_createBufferQueueAudioPlayer(JNIEnv* env,


### PR DESCRIPTION
This prevents the associated resources from being leaked and causing
degraded performance.

Fixes #13 