### PR TITLE
Add an option to record screen brightness curve

### DIFF
--- a/android/WALT/app/src/main/res/drawable/ic_equalizer_black_24dp.xml
+++ b/android/WALT/app/src/main/res/drawable/ic_equalizer_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M10,20h4V4h-4v16zm-6,0h4v-8H4v8zM16,9v11h4V9h-4z"/>
+</vector>

--- a/android/WALT/app/src/main/res/layout/fragment_screen_response.xml
+++ b/android/WALT/app/src/main/res/layout/fragment_screen_response.xml
@@ -21,12 +21,25 @@
                 android:layout_alignParentLeft="true"
                 android:src="@drawable/ic_refresh_black_24dp" />
 
-            <ImageButton
-                android:id="@+id/button_start_screen_response"
+
+            <LinearLayout
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_alignParentRight="true"
-                android:src="@drawable/ic_play_arrow_black_24dp" />
+                android:orientation="horizontal">
+                <ImageButton
+                    android:id="@+id/button_brightness_curve"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentRight="true"
+                    android:src="@drawable/ic_equalizer_black_24dp" />
+                <ImageButton
+                    android:id="@+id/button_start_screen_response"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentRight="true"
+                    android:src="@drawable/ic_play_arrow_black_24dp" />
+            </LinearLayout>
         </RelativeLayout>
 
         <!-- The big box that flickers between black and white -->

--- a/arduino/walt/walt.ino
+++ b/arduino/walt/walt.ino
@@ -31,6 +31,7 @@
 #define CMD_AUTO_SCREEN_ON      'C'
 #define CMD_AUTO_SCREEN_OFF     'c'
 #define CMD_SEND_LAST_SCREEN    'E'
+#define CMD_BRIGHTNESS_CURVE      'U'
 
 #define CMD_AUTO_LASER_ON       'L'
 #define CMD_AUTO_LASER_OFF      'l'
@@ -49,7 +50,7 @@
 // for most LEDs.
 #define LED_PIN_GREEN 16
 #define LED_PIN_RED 17
-#define LED_PIN_YELLOW 5  // or 21
+#define DEBUG_LED2 21
 
 // Pins for the relay based touch probes, collide with LEDs above
 #define TOUCH_PIN_A 16
@@ -155,7 +156,7 @@ void init_vars() {
 void setup() {
   pinMode(LED_PIN_RED, OUTPUT);
   pinMode(LED_PIN_GREEN, OUTPUT);
-  pinMode(LED_PIN_YELLOW, OUTPUT);
+  pinMode(DEBUG_LED2, OUTPUT);
   pinMode(LED_PIN_INT, OUTPUT);
 
   pinMode(TOUCH_PIN_A, OUTPUT);
@@ -176,6 +177,25 @@ void setup() {
   init_vars();
 }
 
+
+void run_brightness_curve() {
+  int i;
+  long t;
+  short v;
+  digitalWrite(DEBUG_LED2, HIGH);
+  for (i = 0; i < 1000; i++) {
+    v = analogRead(PD_SCREEN_PIN);
+    t = time_us;
+    Serial.print(t);
+    Serial.print(" ");
+    Serial.println(v);
+    delayMicroseconds(450);
+  }
+  digitalWrite(DEBUG_LED2, LOW);
+  Serial.send_now();
+  Serial.println("end");
+  Serial.send_now();
+}
 
 void process_command(char cmd) {
   int i;
@@ -284,6 +304,10 @@ void process_command(char cmd) {
     } else if (cmd == CMD_SEND_LAST_LASER) {
       send_trigger(laser);
       laser.count = 0;
+    } else if (cmd == CMD_BRIGHTNESS_CURVE) {
+      send_ack(CMD_BRIGHTNESS_CURVE);
+      // This blocks all other execution for about 1 second
+      run_brightness_curve();
     } else {
       Serial.print("Unknown command:");
       Serial.println(cmd);


### PR DESCRIPTION
Records screen brightness during transition from balck to white and back at 2 kHz sampling rate.
The black to white transition usually takes several milliseconds and it's important to know how it looks like and where ther threshold used for binary black/white detection is on this curve.

For now the data is dumped into the main log, no graphical display yet.