### PR TITLE
Disable/enable buttons based on test state

### DIFF
--- a/android/WALT/app/src/main/java/org/chromium/latency/walt/AboutFragment.java
+++ b/android/WALT/app/src/main/java/org/chromium/latency/walt/AboutFragment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 The Android Open Source Project
+ * Copyright (C) 2017 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/android/WALT/app/src/main/java/org/chromium/latency/walt/BaseTest.java
+++ b/android/WALT/app/src/main/java/org/chromium/latency/walt/BaseTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.chromium.latency.walt;
+
+import android.content.Context;
+
+abstract class BaseTest {
+
+    interface TestStateListener {
+        void onTestStopped();
+    }
+
+    SimpleLogger logger;
+    WaltDevice waltDevice;
+    TestStateListener testStateListener = null;
+    AutoRunFragment.ResultHandler resultHandler = null;
+
+    BaseTest(Context context) {
+        waltDevice = WaltDevice.getInstance(context);
+        logger = SimpleLogger.getInstance(context);
+    }
+
+    void setTestStateListener(TestStateListener listener) {
+        this.testStateListener = listener;
+    }
+}

--- a/android/WALT/app/src/main/res/color/button_tint.xml
+++ b/android/WALT/app/src/main/res/color/button_tint.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="false" android:color="#FFABABAB"/>
+    <item android:state_enabled="true" android:color="#FF000000"/>
+</selector>

--- a/android/WALT/app/src/main/res/layout/fragment_audio.xml
+++ b/android/WALT/app/src/main/res/layout/fragment_audio.xml
@@ -19,6 +19,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_alignParentLeft="true"
+                android:tint="@color/button_tint"
                 android:src="@drawable/ic_mic_black_24dp" />
 
             <ImageButton
@@ -26,6 +27,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_alignParentRight="true"
+                android:tint="@color/button_tint"
                 android:src="@drawable/ic_play_arrow_black_24dp" />
         </RelativeLayout>
 

--- a/android/WALT/app/src/main/res/layout/fragment_drag_latency.xml
+++ b/android/WALT/app/src/main/res/layout/fragment_drag_latency.xml
@@ -18,19 +18,21 @@
                 android:id="@+id/button_restart_drag"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:tint="@color/button_tint"
                 android:src="@drawable/ic_refresh_black_24dp" />
 
             <ImageButton
                 android:id="@+id/button_start_drag"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:tint="@color/button_tint"
                 android:src="@drawable/ic_play_arrow_black_24dp" />
 
             <ImageButton
                 android:id="@+id/button_finish_drag"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_alignParentRight="true"
+                android:tint="@color/button_tint"
                 android:src="@drawable/ic_check_black_24dp" />
         </LinearLayout>
 

--- a/android/WALT/app/src/main/res/layout/fragment_midi.xml
+++ b/android/WALT/app/src/main/res/layout/fragment_midi.xml
@@ -19,6 +19,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_alignParentStart="true"
+                android:tint="@color/button_tint"
                 android:src="@drawable/ic_input_black_24dp" />
 
             <ImageButton
@@ -26,6 +27,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_alignParentEnd="true"
+                android:tint="@color/button_tint"
                 android:src="@drawable/ic_output_black_24dp" />
         </RelativeLayout>
 

--- a/android/WALT/app/src/main/res/layout/fragment_screen_response.xml
+++ b/android/WALT/app/src/main/res/layout/fragment_screen_response.xml
@@ -19,27 +19,24 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_alignParentLeft="true"
+                android:tint="@color/button_tint"
                 android:src="@drawable/ic_refresh_black_24dp" />
 
-
-            <LinearLayout
+            <ImageButton
+                android:id="@+id/button_start_screen_response"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_alignParentRight="true"
-                android:orientation="horizontal">
-                <ImageButton
-                    android:id="@+id/button_brightness_curve"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_alignParentRight="true"
-                    android:src="@drawable/ic_equalizer_black_24dp" />
-                <ImageButton
-                    android:id="@+id/button_start_screen_response"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_alignParentRight="true"
-                    android:src="@drawable/ic_play_arrow_black_24dp" />
-            </LinearLayout>
+                android:tint="@color/button_tint"
+                android:src="@drawable/ic_play_arrow_black_24dp" />
+
+            <ImageButton
+                android:id="@+id/button_brightness_curve"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_toLeftOf="@id/button_start_screen_response"
+                android:tint="@color/button_tint"
+                android:src="@drawable/ic_equalizer_black_24dp" />
         </RelativeLayout>
 
         <!-- The big box that flickers between black and white -->


### PR DESCRIPTION
# Changes
Disable the start/finish/restart buttons where appropriate, based on whether the test is running or not. This affects Drag Latency, Screen Response, Audio Latency, and MIDI Latency fragments.

# Future Work
Change the UI for ScreenResponseFragment to be more usable:
+ Change the reset button to a stop button
+ Remove the brightness profile button and add a spinner to select between brightness curve profile and blink latency.

# Screenshots
![disable-btn](https://cloud.githubusercontent.com/assets/1626670/22351564/961f8904-e3e6-11e6-8c2c-6893daa4ce1f.png)
