### PR TITLE
Polish UI, Automatically increase screen brightness

### DIFF
--- a/android/WALT/app/src/main/java/org/chromium/latency/walt/CustomNumberPicker.java
+++ b/android/WALT/app/src/main/java/org/chromium/latency/walt/CustomNumberPicker.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.chromium.latency.walt;
+
+import android.content.Context;
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.util.AttributeSet;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.EditText;
+import android.widget.NumberPicker;
+
+public class CustomNumberPicker extends NumberPicker {
+
+    public CustomNumberPicker(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    @Override
+    public void addView(View child) {
+        super.addView(child);
+        initEditText(child);
+    }
+
+    @Override
+    public void addView(View child, int index) {
+        super.addView(child, index);
+        initEditText(child);
+    }
+
+    @Override
+    public void addView(View child, int index, ViewGroup.LayoutParams params) {
+        super.addView(child, index, params);
+        initEditText(child);
+    }
+
+    @Override
+    public void addView(View child, ViewGroup.LayoutParams params) {
+        super.addView(child, params);
+        initEditText(child);
+    }
+
+    @Override
+    public void addView(View child, int width, int height) {
+        super.addView(child, width, height);
+        initEditText(child);
+    }
+
+    private void initEditText(View view) {
+        if (view instanceof EditText) {
+            EditText inputText = (EditText) view;
+            inputText.addTextChangedListener(new TextWatcher() {
+                @Override
+                public void onTextChanged(CharSequence s, int start, int before, int count) {
+                    try {
+                        CustomNumberPicker.this.setValue(Integer.parseInt(s.toString()));
+                    } catch (NumberFormatException ignored) {}
+                }
+
+                @Override
+                public void afterTextChanged(Editable s) {}
+
+                @Override
+                public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
+            });
+        }
+    }
+}

--- a/android/WALT/app/src/main/java/org/chromium/latency/walt/DiagnosticsFragment.java
+++ b/android/WALT/app/src/main/java/org/chromium/latency/walt/DiagnosticsFragment.java
@@ -17,7 +17,6 @@
 package org.chromium.latency.walt;
 
 
-import android.app.Activity;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -35,9 +34,8 @@ import android.widget.TextView;
  */
 public class DiagnosticsFragment extends Fragment {
 
-    private Activity activity;
     private SimpleLogger logger;
-    TextView mTextView;
+    private TextView logTextView;
 
 
     private BroadcastReceiver mLogReceiver = new BroadcastReceiver() {
@@ -58,18 +56,16 @@ public class DiagnosticsFragment extends Fragment {
                              Bundle savedInstanceState) {
         logger = SimpleLogger.getInstance(getContext());
         // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_diagnostics, container, false);
+        final View view = inflater.inflate(R.layout.fragment_diagnostics, container, false);
+        logTextView = (TextView) view.findViewById(R.id.txt_log_diag);
+        return view;
     }
 
     @Override
     public void onResume() {
         super.onResume();
-        activity = getActivity();
-
-        mTextView = (TextView) activity.findViewById(R.id.txt_log_diag);
-        mTextView.setMovementMethod(new ScrollingMovementMethod());
-        mTextView.setText(logger.getLogText());
-
+        logTextView.setMovementMethod(new ScrollingMovementMethod());
+        logTextView.setText(logger.getLogText());
         logger.registerReceiver(mLogReceiver);
     }
 
@@ -81,6 +77,6 @@ public class DiagnosticsFragment extends Fragment {
 
 
     public void appendLogText(String msg) {
-        mTextView.append(msg + "\n");
+        logTextView.append(msg + "\n");
     }
 }

--- a/android/WALT/app/src/main/java/org/chromium/latency/walt/NumberPickerPreference.java
+++ b/android/WALT/app/src/main/java/org/chromium/latency/walt/NumberPickerPreference.java
@@ -21,11 +21,9 @@ import android.content.res.TypedArray;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v7.preference.DialogPreference;
-import android.support.v7.preference.Preference;
 import android.support.v7.preference.PreferenceDialogFragmentCompat;
 import android.util.AttributeSet;
 import android.view.View;
-import android.widget.NumberPicker;
 
 public class NumberPickerPreference extends DialogPreference {
     private int currentValue;
@@ -82,7 +80,7 @@ public class NumberPickerPreference extends DialogPreference {
     public static class NumberPickerPreferenceDialogFragmentCompat
             extends PreferenceDialogFragmentCompat {
         private static final String SAVE_STATE_VALUE = "NumberPickerPreferenceDialogFragment.value";
-        private NumberPicker picker;
+        private CustomNumberPicker picker;
         private int currentValue = 1;
 
         public NumberPickerPreferenceDialogFragmentCompat() {
@@ -117,7 +115,7 @@ public class NumberPickerPreference extends DialogPreference {
         @Override
         protected void onBindDialogView(View view) {
             super.onBindDialogView(view);
-            picker = (NumberPicker) view.findViewById(R.id.numpicker_pref);
+            picker = (CustomNumberPicker) view.findViewById(R.id.numpicker_pref);
             picker.setMaxValue(getNumberPickerPreference().maxValue);
             picker.setMinValue(getNumberPickerPreference().minValue);
             picker.setValue(currentValue);

--- a/android/WALT/app/src/main/java/org/chromium/latency/walt/ScreenResponseFragment.java
+++ b/android/WALT/app/src/main/java/org/chromium/latency/walt/ScreenResponseFragment.java
@@ -25,12 +25,14 @@ import android.view.Choreographer;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.WindowManager;
 import android.widget.TextView;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Locale;
 
+import static org.chromium.latency.walt.Utils.getBooleanPreference;
 import static org.chromium.latency.walt.Utils.getIntPreference;
 
 /**
@@ -78,6 +80,10 @@ public class ScreenResponseFragment extends Fragment implements View.OnClickList
         brightnessCurveButton = view.findViewById(R.id.button_brightness_curve);
         blackBox = (TextView) view.findViewById(R.id.txt_black_box_screen);
         resetScreenButton.setEnabled(false);
+
+        if (getBooleanPreference(getContext(), R.string.preference_auto_increase_brightness, true)) {
+            increaseScreenBrightness();
+        }
         return view;
     }
 
@@ -368,5 +374,11 @@ public class ScreenResponseFragment extends Fragment implements View.OnClickList
         resetScreenButton.setEnabled(true);
         startButton.setEnabled(true);
         brightnessCurveButton.setEnabled(true);
+    }
+
+    private void increaseScreenBrightness() {
+        final WindowManager.LayoutParams layoutParams = getActivity().getWindow().getAttributes();
+        layoutParams.screenBrightness = 1f;
+        getActivity().getWindow().setAttributes(layoutParams);
     }
 }

--- a/android/WALT/app/src/main/java/org/chromium/latency/walt/Utils.java
+++ b/android/WALT/app/src/main/java/org/chromium/latency/walt/Utils.java
@@ -30,7 +30,7 @@ import java.util.InputMismatchException;
  */
 public class Utils {
     public static double median(ArrayList<Double> arrList) {
-        ArrayList<Double> lst = new ArrayList<Double>(arrList);
+        ArrayList<Double> lst = new ArrayList<>(arrList);
         Collections.sort(lst);
         int len = lst.size();
         if (len == 0) {
@@ -165,6 +165,11 @@ public class Utils {
     static int getIntPreference(Context context, @StringRes int keyId, int defaultValue) {
         SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
         return preferences.getInt(context.getString(keyId), defaultValue);
+    }
+
+    static boolean getBooleanPreference(Context context, @StringRes int keyId, boolean defaultValue) {
+        SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
+        return preferences.getBoolean(context.getString(keyId), defaultValue);
     }
 
     public enum ListenerState {

--- a/android/WALT/app/src/main/java/org/chromium/latency/walt/WaltTcpConnection.java
+++ b/android/WALT/app/src/main/java/org/chromium/latency/walt/WaltTcpConnection.java
@@ -19,7 +19,6 @@ package org.chromium.latency.walt;
 import android.content.Context;
 import android.os.Handler;
 import android.os.HandlerThread;
-import android.os.SystemClock;
 import android.util.Log;
 
 import java.io.IOException;
@@ -29,9 +28,6 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
-import java.util.Locale;
-
-import static android.os.SystemClock.uptimeMillis;
 
 
 public class WaltTcpConnection implements WaltConnection {
@@ -44,7 +40,7 @@ public class WaltTcpConnection implements WaltConnection {
     private final SimpleLogger mLogger;
     private HandlerThread networkThread;
     private Handler networkHandler;
-    private Object mReadLock = new Object();
+    private final Object mReadLock = new Object();
     private boolean messageReceived = false;
     private Utils.ListenerState mConnectionState = Utils.ListenerState.STOPPED;
     private int lastRetVal;
@@ -232,7 +228,7 @@ public class WaltTcpConnection implements WaltConnection {
 
         @Override
         public void run() {
-            Socket socket = new Socket();;
+            Socket socket = new Socket();
             try {
                 InetSocketAddress remoteAddr = new InetSocketAddress(SERVER_IP, SERVER_PORT);
                 socket.connect(remoteAddr, 50 /* timeout in milliseconds */);

--- a/android/WALT/app/src/main/res/layout/activity_crash_log.xml
+++ b/android/WALT/app/src/main/res/layout/activity_crash_log.xml
@@ -1,5 +1,4 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 

--- a/android/WALT/app/src/main/res/layout/fragment_diagnostics.xml
+++ b/android/WALT/app/src/main/res/layout/fragment_diagnostics.xml
@@ -36,6 +36,7 @@
                         android:text="Reconnect" />
 
                     <TextView
+                        android:visibility="gone"
                         style="@style/MenuTextBottom"
                         android:text="TBD: Conn status" />
 

--- a/android/WALT/app/src/main/res/layout/fragment_tap_latency.xml
+++ b/android/WALT/app/src/main/res/layout/fragment_tap_latency.xml
@@ -9,23 +9,26 @@
         android:layout_height="match_parent"
         android:orientation="vertical">
 
-        <LinearLayout
+        <RelativeLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
-
-            <ImageButton
-                android:id="@+id/button_restart_tap"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:src="@drawable/ic_refresh_black_24dp" />
+            android:layout_height="wrap_content">
 
             <ImageButton
                 android:id="@+id/button_finish_tap"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_alignParentLeft="true"
+                android:tint="@color/button_tint"
                 android:src="@drawable/ic_check_black_24dp" />
-        </LinearLayout>
+
+            <ImageButton
+                android:id="@+id/button_restart_tap"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentRight="true"
+                android:tint="@color/button_tint"
+                android:src="@drawable/ic_play_arrow_black_24dp" />
+        </RelativeLayout>
 
         <FrameLayout
             android:layout_width="match_parent"

--- a/android/WALT/app/src/main/res/layout/numberpicker_dialog.xml
+++ b/android/WALT/app/src/main/res/layout/numberpicker_dialog.xml
@@ -11,7 +11,7 @@
         android:layout_height="wrap_content"
         android:layout_marginBottom="8dp"
         android:textAppearance="?android:attr/textAppearanceMedium"/>
-    <NumberPicker
+    <org.chromium.latency.walt.CustomNumberPicker
         android:id="@+id/numpicker_pref"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/android/WALT/app/src/main/res/menu/menu_main.xml
+++ b/android/WALT/app/src/main/res/menu/menu_main.xml
@@ -9,23 +9,20 @@
         android:orderInCategory="180"
         android:title="Upload"
         android:icon="@drawable/ic_file_upload_black_24dp"
-        app:showAsAction="ifRoom"
-        ></item>
+        app:showAsAction="ifRoom" />
 
     <item
         android:id="@+id/action_share"
         android:orderInCategory="190"
         android:title="Share"
         android:icon="@drawable/ic_share_black_24dp"
-        app:showAsAction="ifRoom"
-        ></item>
+        app:showAsAction="ifRoom" />
 
     <item
         android:id="@+id/action_help"
         android:orderInCategory="200"
         android:title="Help"
         android:icon="@drawable/ic_help_outline_black_24dp"
-        app:showAsAction="ifRoom"
-        ></item>
+        app:showAsAction="ifRoom" />
 
 </menu>

--- a/android/WALT/app/src/main/res/values/strings.xml
+++ b/android/WALT/app/src/main/res/values/strings.xml
@@ -20,6 +20,7 @@
     <string name="preference_audio_out_reps" translatable="false">pref_audio_out_reps</string>
     <string name="preference_midi_in_reps" translatable="false">pref_midi_in_reps</string>
     <string name="preference_midi_out_reps" translatable="false">pref_midi_out_reps</string>
+    <string name="preference_auto_increase_brightness">auto_increase_brightness</string>
     <string-array name="audio_mode_array">
         <item>Continuous Latency</item>
         <item>Cold Latency</item>

--- a/android/WALT/app/src/main/res/xml/preferences.xml
+++ b/android/WALT/app/src/main/res/xml/preferences.xml
@@ -15,6 +15,11 @@
             walt:maxValue="1000"
             walt:minValue="1" />
 
+        <SwitchPreference
+            android:key="@string/preference_auto_increase_brightness"
+            android:title="Automatically increase brightness for test"
+            android:defaultValue="true" />
+
     </android.support.v7.preference.PreferenceScreen>
 
     <android.support.v7.preference.PreferenceScreen


### PR DESCRIPTION
# Changes

+ General UI polish
+ Fix some lint warnings
+ Address issue #66 (bug in NumberPicker in settings)
+ Add "start" button to tap latency (which converts to restart button). Tap events are not measured while test is not running, making it easier to recording measurements and read the log.
+ Automatically increase screen brightness for the Screen Response tests (can be disabled in settings, but true by default)