### PR TITLE
Change Screen Response UI

### DIFF
--- a/android/WALT/app/src/main/res/drawable/ic_stop_black_24dp.xml
+++ b/android/WALT/app/src/main/res/drawable/ic_stop_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M6,6h12v12H6z"/>
+</vector>

--- a/android/WALT/app/src/main/res/layout/fragment_audio.xml
+++ b/android/WALT/app/src/main/res/layout/fragment_audio.xml
@@ -29,13 +29,16 @@
                 android:layout_alignParentRight="true"
                 android:tint="@color/button_tint"
                 android:src="@drawable/ic_play_arrow_black_24dp" />
-        </RelativeLayout>
 
-        <Spinner
-            android:id="@+id/spinner_audio_mode"
-            android:layout_height="30dp"
-            android:layout_width="fill_parent"
-            android:prompt="@string/audio_mode"/>
+            <Spinner
+                android:id="@+id/spinner_audio_mode"
+                android:layout_height="40dp"
+                android:layout_width="fill_parent"
+                android:layout_toRightOf="@id/button_start_audio_rec"
+                android:layout_toLeftOf="@id/button_start_audio_play"
+                android:prompt="@string/audio_mode"/>
+
+        </RelativeLayout>
 
         <!-- For now the results are just listed in this textView -->
         <TextView

--- a/android/WALT/app/src/main/res/layout/fragment_screen_response.xml
+++ b/android/WALT/app/src/main/res/layout/fragment_screen_response.xml
@@ -15,12 +15,12 @@
             android:orientation="horizontal">
 
             <ImageButton
-                android:id="@+id/button_restart_screen_response"
+                android:id="@+id/button_stop_screen_response"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_alignParentLeft="true"
                 android:tint="@color/button_tint"
-                android:src="@drawable/ic_refresh_black_24dp" />
+                android:src="@drawable/ic_stop_black_24dp" />
 
             <ImageButton
                 android:id="@+id/button_start_screen_response"
@@ -30,13 +30,13 @@
                 android:tint="@color/button_tint"
                 android:src="@drawable/ic_play_arrow_black_24dp" />
 
-            <ImageButton
-                android:id="@+id/button_brightness_curve"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
+            <Spinner
+                android:id="@+id/spinner_screen_response"
+                android:layout_height="40dp"
+                android:layout_width="fill_parent"
+                android:layout_toRightOf="@id/button_stop_screen_response"
                 android:layout_toLeftOf="@id/button_start_screen_response"
-                android:tint="@color/button_tint"
-                android:src="@drawable/ic_equalizer_black_24dp" />
+                android:prompt="@string/screen_response_mode"/>
         </RelativeLayout>
 
         <!-- The big box that flickers between black and white -->
@@ -44,7 +44,7 @@
             android:id="@+id/txt_black_box_screen"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:background="#000000"
+            android:background="#aaaaaa"
             android:gravity="bottom"
             android:scrollbars="vertical"/>
 

--- a/android/WALT/app/src/main/res/values/strings.xml
+++ b/android/WALT/app/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
         supported. Please program WALT to a firmware with protocol version %2$s. To do this
         from the app, choose "Reprogram" from the "Diagnostics" menu.</string>
     <string name="audio_mode">Audio Testing Mode</string>
+    <string name="screen_response_mode">Screen Testing Mode</string>
     <string name="about_description">WALT is designed to measure the latency of physical sensors
         and outputs on phones and computers. It can currently perform the following measurements:
         tap latency, drag latency (scroll), screen draw latency, audio output/microphone
@@ -24,6 +25,10 @@
     <string-array name="audio_mode_array">
         <item>Continuous Latency</item>
         <item>Cold Latency</item>
+    </string-array>
+    <string-array name="screen_response_mode_array">
+        <item>Blink Latency</item>
+        <item>Brightness Curve</item>
     </string-array>
 
 </resources>


### PR DESCRIPTION
The restart button is gone, and replaced with a stop button. This stop button is only enabled while the blink latency test is running (brightness curve test is too fast to abort). The brightness curve test is now run by changing the spinner from `Blink Latency` to `Brightness Curve`. Previously, the user would have to press the restart button before running the brightness curve test. Now, the screen turns black and waits a few milliseconds before starting the test. Also, the app won't crash if WALT is not connected when running the screen response tests (#62).