### PR TITLE
Draw brightness curve data as line chart

### DIFF
--- a/android/WALT/app/build.gradle
+++ b/android/WALT/app/build.gradle
@@ -36,4 +36,5 @@ dependencies {
     compile 'com.android.support:design:23.4.0'
     compile 'com.android.support:preference-v7:23.4.0'
     compile 'com.android.support:preference-v14:23.4.0'
+    compile 'com.github.PhilJay:MPAndroidChart:v3.0.1'
 }

--- a/android/WALT/app/src/main/res/drawable/border.xml
+++ b/android/WALT/app/src/main/res/drawable/border.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="2dp"/>
+    <stroke android:width="1dp" android:color="#000000"/>
+</shape>

--- a/android/WALT/app/src/main/res/layout/fragment_screen_response.xml
+++ b/android/WALT/app/src/main/res/layout/fragment_screen_response.xml
@@ -39,6 +39,30 @@
                 android:prompt="@string/screen_response_mode"/>
         </RelativeLayout>
 
+        <RelativeLayout
+            android:id="@+id/chart_layout"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_margin="5dp"
+            android:background="@drawable/border"
+            android:visibility="gone">
+            <com.github.mikephil.charting.charts.LineChart
+                android:id="@+id/chart"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_margin="10dp"
+                android:gravity="bottom" />
+            <Button
+                android:id="@+id/button_close_chart"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentRight="true"
+                android:layout_alignParentTop="true"
+                android:tint="@color/button_tint"
+                android:layout_margin="5dp"
+                android:text="Close" />
+        </RelativeLayout>
+
         <!-- The big box that flickers between black and white -->
         <TextView
             android:id="@+id/txt_black_box_screen"

--- a/android/WALT/build.gradle
+++ b/android/WALT/build.gradle
@@ -15,5 +15,6 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        maven { url "https://jitpack.io" }
     }
 }


### PR DESCRIPTION
+ Parses the (timestamp,brightness) data from WALT and draws it as a line chart
+ Chart can be zoomed/panned

Future work: add ability to save chart

![brightness-curve](https://cloud.githubusercontent.com/assets/1626670/22669583/41ef8540-ec93-11e6-9319-977e3492a17a.png)
@adlr 