### PR TITLE
Draw live histogram for blink latency test

### DIFF
--- a/android/WALT/app/src/main/java/org/chromium/latency/walt/HistogramChart.java
+++ b/android/WALT/app/src/main/java/org/chromium/latency/walt/HistogramChart.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (C) 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.chromium.latency.walt;
+
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.util.AttributeSet;
+
+import com.github.mikephil.charting.charts.BarChart;
+import com.github.mikephil.charting.components.AxisBase;
+import com.github.mikephil.charting.components.Description;
+import com.github.mikephil.charting.components.XAxis;
+import com.github.mikephil.charting.data.BarData;
+import com.github.mikephil.charting.data.BarDataSet;
+import com.github.mikephil.charting.data.BarEntry;
+import com.github.mikephil.charting.formatter.IAxisValueFormatter;
+import com.github.mikephil.charting.interfaces.datasets.IBarDataSet;
+import com.github.mikephil.charting.utils.ColorTemplate;
+
+import java.text.DecimalFormat;
+import java.util.ArrayList;
+
+public class HistogramChart extends BarChart {
+
+    private static final float BIN_WIDTH = 5;
+    private final ArrayList<ArrayList<Double>> rawData;
+    private final ArrayList<IBarDataSet> dataSets;
+
+    private int minBin = 0;
+    private int maxBin = 100;
+    private double min = 0;
+    private double max = 100;
+
+    public HistogramChart(Context context, AttributeSet attrs) {
+        super(context, attrs);
+
+        final TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.HistogramChart);
+        final String descString;
+        final int numDataSets;
+        try {
+            descString = a.getString(R.styleable.HistogramChart_description);
+            numDataSets = a.getInteger(R.styleable.HistogramChart_numDataSets, 1);
+        } finally {
+            a.recycle();
+        }
+
+        rawData = new ArrayList<>(numDataSets);
+        dataSets = new ArrayList<>(numDataSets);
+        for (int i = 0; i < numDataSets; i++) {
+            rawData.add(new ArrayList<Double>());
+            final BarDataSet dataSet = new BarDataSet(new ArrayList<BarEntry>(), "");
+            dataSet.setColor(ColorTemplate.MATERIAL_COLORS[i]);
+            dataSets.add(dataSet);
+        }
+
+        BarData barData = new BarData(dataSets);
+        barData.setBarWidth(0.45f);
+        setData(barData);
+        groupBars(minBin, 0.08f, 0.01f);
+        final Description desc = new Description();
+        desc.setText(descString);
+        desc.setTextSize(12f);
+        setDescription(desc);
+
+        XAxis xAxis = getXAxis();
+        xAxis.setCenterAxisLabels(true);
+        xAxis.setGranularityEnabled(true);
+        xAxis.setGranularity(1);
+        xAxis.setValueFormatter(new IAxisValueFormatter() {
+            DecimalFormat df = new DecimalFormat("#.##");
+
+            @Override
+            public String getFormattedValue(float value, AxisBase axis) {
+                final float mid = (value - minBin) * BIN_WIDTH + minBin;
+                if (axis.mEntries.length > 1) {
+                    final float width = (axis.mEntries[1] - axis.mEntries[0])*BIN_WIDTH;
+                    return df.format(mid - width/2) + " - " + df.format(mid + width/2);
+                } else {
+                    return df.format(mid);
+                }
+            }
+        });
+
+        invalidate();
+    }
+
+    public void clearData() {
+        for (int i = 0; i < rawData.size(); i++) {
+            rawData.get(i).clear();
+            dataSets.get(i).clear();
+        }
+        invalidate();
+    }
+
+    void addEntry(int dataSetIndex, double value) {
+        if (isRawDataEmpty()) {
+            min = value;
+            max = value;
+        } else {
+            if (value < min) min = value;
+            if (value > max) max = value;
+        }
+
+        rawData.get(dataSetIndex).add(value);
+        minBin = (int) (Math.floor(min/BIN_WIDTH)*BIN_WIDTH);
+        maxBin = (int) (Math.ceil(max/BIN_WIDTH)*BIN_WIDTH);
+
+        final int numBins = (int) ((maxBin - minBin) / BIN_WIDTH + 1);
+        int[][] bins = new int[rawData.size()][numBins];
+
+        for (int i = 0; i < rawData.size(); i++) {
+            for (Double d : rawData.get(i)) {
+                ++bins[i][(int) (Math.round((d - minBin)/ BIN_WIDTH))];
+            }
+        }
+
+        for (IBarDataSet dataSet : dataSets) {
+            dataSet.clear();
+        }
+
+        for (int x = 0; x < dataSets.size(); x++) {
+            for (int i = 0; i < bins[x].length; i++) {
+                dataSets.get(x).addEntry(new BarEntry(i, bins[x][i]));
+            }
+        }
+
+        mXAxis.setAxisMinimum(minBin);
+        mXAxis.setAxisMaximum(minBin + numBins);
+        groupBars(minBin, 0.08f, 0.01f);
+        setFitBars(true);
+        invalidate();
+    }
+
+    private boolean isRawDataEmpty() {
+        for (ArrayList<Double> data : rawData) {
+            if (!data.isEmpty()) return false;
+        }
+        return true;
+    }
+
+    public void setLabel(int dataSetIndex, String label) {
+        dataSets.get(dataSetIndex).setLabel(label);
+    }
+}

--- a/android/WALT/app/src/main/java/org/chromium/latency/walt/ScreenResponseFragment.java
+++ b/android/WALT/app/src/main/java/org/chromium/latency/walt/ScreenResponseFragment.java
@@ -120,8 +120,8 @@ public class ScreenResponseFragment extends Fragment implements View.OnClickList
         view.findViewById(R.id.button_close_latency_chart).setOnClickListener(this);
         brightnessChart = (LineChart) view.findViewById(R.id.chart);
         latencyChart = (HistogramChart) view.findViewById(R.id.latency_chart);
-        latencyChart.setLabel(W2B_INDEX, "White-to-black Latency");
-        latencyChart.setLabel(B2W_INDEX, "Black-to-white Latency");
+        latencyChart.setLabel(W2B_INDEX, "White-to-black");
+        latencyChart.setLabel(B2W_INDEX, "Black-to-white");
 
         if (getBooleanPreference(getContext(), R.string.preference_auto_increase_brightness, true)) {
             increaseScreenBrightness();
@@ -317,6 +317,8 @@ public class ScreenResponseFragment extends Fragment implements View.OnClickList
         blackBox.setBackgroundColor(color_gray);
         stopButton.setEnabled(false);
         startButton.setEnabled(true);
+        latencyChart.setLabel(W2B_INDEX, String.format(Locale.US, "White-to-black m=%.1f", median_w2b));
+        latencyChart.setLabel(B2W_INDEX, String.format(Locale.US, "Black-to-white m=%.1f", median_b2w));
     }
 
     @Override

--- a/android/WALT/app/src/main/java/org/chromium/latency/walt/ScreenResponseFragment.java
+++ b/android/WALT/app/src/main/java/org/chromium/latency/walt/ScreenResponseFragment.java
@@ -54,6 +54,8 @@ public class ScreenResponseFragment extends Fragment implements View.OnClickList
 
     private static final int CURVE_TIMEOUT = 1000;  // milliseconds
     private static final int CURVE_BLINK_TIME = 250;  // milliseconds
+    private static final int W2B_INDEX = 0;
+    private static final int B2W_INDEX = 1;
     private SimpleLogger logger;
     private WaltDevice waltDevice;
     private Handler handler = new Handler();
@@ -61,8 +63,10 @@ public class ScreenResponseFragment extends Fragment implements View.OnClickList
     private View startButton;
     private View stopButton;
     private Spinner spinner;
-    private LineChart chart;
-    private View chartLayout;
+    private LineChart brightnessChart;
+    private HistogramChart latencyChart;
+    private View brightnessChartLayout;
+    private View latencyChartLayout;
     private int timesToBlink;
     private boolean isTestRunning = false;
     int initiatedBlinks = 0;
@@ -110,9 +114,14 @@ public class ScreenResponseFragment extends Fragment implements View.OnClickList
         spinner.setAdapter(modeAdapter);
         stopButton.setEnabled(false);
         blackBox.setMovementMethod(new ScrollingMovementMethod());
-        chartLayout = view.findViewById(R.id.chart_layout);
+        brightnessChartLayout = view.findViewById(R.id.brightness_chart_layout);
+        latencyChartLayout = view.findViewById(R.id.latency_chart_layout);
         view.findViewById(R.id.button_close_chart).setOnClickListener(this);
-        chart = (LineChart) view.findViewById(R.id.chart);
+        view.findViewById(R.id.button_close_latency_chart).setOnClickListener(this);
+        brightnessChart = (LineChart) view.findViewById(R.id.chart);
+        latencyChart = (HistogramChart) view.findViewById(R.id.latency_chart);
+        latencyChart.setLabel(W2B_INDEX, "White-to-black Latency");
+        latencyChart.setLabel(B2W_INDEX, "Black-to-white Latency");
 
         if (getBooleanPreference(getContext(), R.string.preference_auto_increase_brightness, true)) {
             increaseScreenBrightness();
@@ -139,7 +148,8 @@ public class ScreenResponseFragment extends Fragment implements View.OnClickList
         deltas.clear();
         deltas_b2w.clear();
         deltas_w2b.clear();
-
+        latencyChart.clearData();
+        latencyChartLayout.setVisibility(View.VISIBLE);
         initiatedBlinks = 0;
         detectedBlinks = 0;
 
@@ -247,8 +257,10 @@ public class ScreenResponseFragment extends Fragment implements View.OnClickList
             deltas.add(dt);
             if (isBoxWhite) {  // Current color is the color we transitioned to
                 deltas_b2w.add(dt);
+                latencyChart.addEntry(B2W_INDEX, dt);
             } else {
                 deltas_w2b.add(dt);
+                latencyChart.addEntry(W2B_INDEX, dt);
             }
 
             // Other times can be important, logging them to allow more detailed analysis
@@ -318,7 +330,8 @@ public class ScreenResponseFragment extends Fragment implements View.OnClickList
         }
 
         if (v.getId() == R.id.button_start_screen_response) {
-            chartLayout.setVisibility(View.GONE);
+            brightnessChartLayout.setVisibility(View.GONE);
+            latencyChartLayout.setVisibility(View.GONE);
             if (!waltDevice.isConnected()) {
                 logger.log("Error starting test: WALT is not connected");
                 return;
@@ -340,7 +353,12 @@ public class ScreenResponseFragment extends Fragment implements View.OnClickList
         }
 
         if (v.getId() == R.id.button_close_chart) {
-            chartLayout.setVisibility(View.GONE);
+            brightnessChartLayout.setVisibility(View.GONE);
+            return;
+        }
+
+        if (v.getId() == R.id.button_close_latency_chart) {
+            latencyChartLayout.setVisibility(View.GONE);
             return;
         }
     }
@@ -457,14 +475,14 @@ public class ScreenResponseFragment extends Fragment implements View.OnClickList
         dataSet.setCircleRadius(1.5f);
         dataSet.setCircleColorHole(Color.DKGRAY);
         LineData lineData = new LineData(dataSet);
-        chart.setData(lineData);
+        brightnessChart.setData(lineData);
         final Description desc = new Description();
         desc.setText("Screen Brightness [digital level 0-1023] vs. Time [ms]");
         desc.setTextSize(12f);
-        chart.setDescription(desc);
-        chart.getLegend().setEnabled(false);
-        chart.invalidate();
-        chartLayout.setVisibility(View.VISIBLE);
+        brightnessChart.setDescription(desc);
+        brightnessChart.getLegend().setEnabled(false);
+        brightnessChart.invalidate();
+        brightnessChartLayout.setVisibility(View.VISIBLE);
     }
 
     private void increaseScreenBrightness() {

--- a/android/WALT/app/src/main/res/layout/fragment_screen_response.xml
+++ b/android/WALT/app/src/main/res/layout/fragment_screen_response.xml
@@ -1,5 +1,6 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:walt="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context="org.chromium.latency.walt.TapLatencyFragment">
@@ -40,14 +41,42 @@
         </RelativeLayout>
 
         <include
-            android:id="@+id/chart_layout"
+            android:id="@+id/brightness_chart_layout"
             layout="@layout/line_chart" />
+
+        <RelativeLayout
+            android:id="@+id/latency_chart_layout"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:layout_margin="5dp"
+            android:background="@drawable/border"
+            android:visibility="gone">
+            <org.chromium.latency.walt.HistogramChart
+                android:id="@+id/latency_chart"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_margin="10dp"
+                android:gravity="bottom"
+                walt:description="Blink Latency [ms]"
+                walt:numDataSets="2" />
+            <Button
+                android:id="@+id/button_close_latency_chart"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentRight="true"
+                android:layout_alignParentTop="true"
+                android:tint="@color/button_tint"
+                android:layout_margin="5dp"
+                android:text="Close" />
+        </RelativeLayout>
 
         <!-- The big box that flickers between black and white -->
         <TextView
             android:id="@+id/txt_black_box_screen"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="2"
             android:background="#aaaaaa"
             android:gravity="bottom"
             android:scrollbars="vertical"/>

--- a/android/WALT/app/src/main/res/values/attrs.xml
+++ b/android/WALT/app/src/main/res/values/attrs.xml
@@ -4,4 +4,8 @@
         <attr name="minValue" format="integer" />
         <attr name="maxValue" format="integer" />
     </declare-styleable>
+    <declare-styleable name="HistogramChart">
+        <attr name="description" format="string" />
+        <attr name="numDataSets" format="integer" />
+    </declare-styleable>
 </resources>


### PR DESCRIPTION
Draws a histogram in realtime, showing the latency distribution for black-to-white and white-to-black separately.

# Future Work
+ Configure `BIN_WIDTH` in settings
+ Once test is finished, expand to fullscreen? Add option to minimize/maximize
![hist-1](https://cloud.githubusercontent.com/assets/1626670/22811766/d5516f10-ef0e-11e6-97f0-af723b1b4380.png)
