### PR TITLE
Display live histogram for tap latency

### DIFF
--- a/android/WALT/app/src/main/java/org/chromium/latency/walt/ScreenResponseFragment.java
+++ b/android/WALT/app/src/main/java/org/chromium/latency/walt/ScreenResponseFragment.java
@@ -117,8 +117,6 @@ public class ScreenResponseFragment extends Fragment implements View.OnClickList
         view.findViewById(R.id.button_close_chart).setOnClickListener(this);
         brightnessChart = (LineChart) view.findViewById(R.id.chart);
         latencyChart = (HistogramChart) view.findViewById(R.id.latency_chart);
-        latencyChart.setLabel(W2B_INDEX, "White-to-black");
-        latencyChart.setLabel(B2W_INDEX, "Black-to-white");
 
         if (getBooleanPreference(getContext(), R.string.preference_auto_increase_brightness, true)) {
             increaseScreenBrightness();
@@ -147,6 +145,8 @@ public class ScreenResponseFragment extends Fragment implements View.OnClickList
         deltas_w2b.clear();
         latencyChart.clearData();
         latencyChart.setVisibility(View.VISIBLE);
+        latencyChart.setLabel(W2B_INDEX, "White-to-black");
+        latencyChart.setLabel(B2W_INDEX, "Black-to-white");
         initiatedBlinks = 0;
         detectedBlinks = 0;
 

--- a/android/WALT/app/src/main/res/layout/fragment_audio.xml
+++ b/android/WALT/app/src/main/res/layout/fragment_audio.xml
@@ -50,7 +50,6 @@
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_weight="1"
-            android:layout_margin="5dp"
             android:visibility="gone"
             walt:description="Latency [ms]"
             walt:binWidth="0.1" />

--- a/android/WALT/app/src/main/res/layout/fragment_screen_response.xml
+++ b/android/WALT/app/src/main/res/layout/fragment_screen_response.xml
@@ -49,7 +49,6 @@
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_weight="1"
-            android:layout_margin="5dp"
             android:visibility="gone"
             walt:description="Blink Latency [ms]"
             walt:numDataSets="2"

--- a/android/WALT/app/src/main/res/layout/fragment_tap_latency.xml
+++ b/android/WALT/app/src/main/res/layout/fragment_tap_latency.xml
@@ -1,5 +1,6 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:walt="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context="org.chromium.latency.walt.TapLatencyFragment">
@@ -67,10 +68,21 @@
                         android:textColor="#ff0000" />
                 </LinearLayout>
 
+                <org.chromium.latency.walt.HistogramChart
+                    android:id="@+id/latency_chart"
+                    android:layout_width="match_parent"
+                    android:layout_height="0dp"
+                    android:layout_weight="1"
+                    android:visibility="gone"
+                    walt:description="Tap Latency [ms]"
+                    walt:binWidth="5"
+                    walt:numDataSets="2" />
+
                 <TextView
                     android:id="@+id/txt_log_tap_latency"
                     android:layout_width="match_parent"
-                    android:layout_height="match_parent"
+                    android:layout_height="0dp"
+                    android:layout_weight="1"
                     android:background="#000000"
                     android:gravity="bottom"
                     android:textColor="#ffffff" />
@@ -82,7 +94,7 @@
                 android:id="@+id/tap_catcher"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:background="#99000000" />
+                android:background="#01000000" />
 
         </FrameLayout>
     </LinearLayout>

--- a/android/WALT/app/src/main/res/layout/histogram.xml
+++ b/android/WALT/app/src/main/res/layout/histogram.xml
@@ -3,6 +3,7 @@
     android:id="@+id/latency_chart_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:layout_margin="5dp"
     android:background="@drawable/border">
     <com.github.mikephil.charting.charts.BarChart
         android:id="@+id/bar_chart"


### PR DESCRIPTION
Adds a histogram which updates while the test is running, displaying physical-to-kernel latency for down and up events. This histogram is tappable during the test.

We may want to make the histogram full-screen once the test is done.

![hist-tap](https://cloud.githubusercontent.com/assets/1626670/22997236/aa1f5402-f39f-11e6-8fc1-7181161e6538.png)
