### PR TITLE
End-to-end tapaudio/tapblink tests

### DIFF
--- a/pywalt/pywalt/walt.py
+++ b/pywalt/pywalt/walt.py
@@ -67,7 +67,7 @@ def log(msg):
 
 
 class Walt(object):
-    """ A class for communicating with Wlat device
+    """ A class for communicating with Walt device
 
     Usage:
     with Walt('/dev/ttyUSB0') as walt:
@@ -92,6 +92,7 @@ class Walt(object):
     CMD_VERSION = 'V'
     CMD_SAMPLE_ALL = 'Q'
     CMD_BRIGHTNESS_CURVE = 'U'
+    CMD_AUDIO = 'A'
 
 
     def __init__(self, serial_dev, timeout=None, encoding='utf-8'):
@@ -298,7 +299,8 @@ def parse_args(argv):
     parser.add_argument('-s', '--serial', default=serial,
                         help='WALT serial port')
     parser.add_argument('-t', '--type',
-                        help='Test type: drag|tap|screen|sanity|curve|bridge')
+                        help='Test type: drag|tap|screen|sanity|curve|bridge|'
+                             'tapaudio|tapblink')
     parser.add_argument('-l', '--logdir', default=temp_dir,
                         help='where to store logs')
     parser.add_argument('-n', default=40, type=int,
@@ -344,7 +346,7 @@ def run_drag_latency_test(args):
         tstart = time.time()
         t_zero = walt.zero_clock()
         if t_zero < 0:
-            print('Error: Couldn\'t zero clock, exitting')
+            print('Error: Couldn\'t zero clock, exiting')
             sys.exit(1)
 
         # Fire up the evtest process
@@ -378,6 +380,7 @@ def run_drag_latency_test(args):
     # lm.main(evtest_file_name, laser_file_name)
     minimization.minimize(evtest_file_name, laser_file_name)
 
+
 def run_screen_curve(args):
 
     with Walt(args.serial, timeout=1) as walt:
@@ -385,7 +388,7 @@ def run_screen_curve(args):
 
         t_zero = walt.zero_clock()
         if t_zero < 0:
-            print('Error: Couldn\'t zero clock, exitting')
+            print('Error: Couldn\'t zero clock, exiting')
             sys.exit(1)
 
         # Fire up the walt_blinker process
@@ -418,7 +421,7 @@ def run_screen_latency_test(args):
 
         t_zero = walt.zero_clock()
         if t_zero < 0:
-            print('Error: Couldn\'t zero clock, exitting')
+            print('Error: Couldn\'t zero clock, exiting')
             sys.exit(1)
 
         # Fire up the walt_blinker process
@@ -455,6 +458,65 @@ def run_screen_latency_test(args):
     screen_stats.screen_stats(blinker_file_name, sensor_file_name)
 
 
+def run_tap_audio_test(args):
+    print('Starting tap-to-audio latency test')
+    with Walt(args.serial) as walt:
+        walt.sndrcv(Walt.CMD_RESET)
+        t_zero = walt.zero_clock()
+        if t_zero < 0:
+            print('Error: Couldn\'t zero clock, exiting')
+            sys.exit(1)
+
+        walt.sndrcv(Walt.CMD_GSHOCK)
+        deltas = []
+        while len(deltas) < args.n:
+            sys.stdout.write('\rWAIT   ')
+            sys.stdout.flush()
+            time.sleep(1)  # Wait for previous beep to stop playing
+            while walt.read_shock_time() != 0:
+                pass  # skip shocks during sleep
+            sys.stdout.write('\rTAP NOW')
+            sys.stdout.flush()
+            walt.sndrcv(Walt.CMD_AUDIO)
+            trigger_line = walt.readline()
+            beep_time_seconds, val = walt.parse_trigger(trigger_line)
+            beep_time_ms = beep_time_seconds * 1e3
+            shock_time_ms = walt.read_shock_time() / 1e3
+            if shock_time_ms == 0:
+                print("\rNo shock detected, skipping this event")
+                continue
+            dt = beep_time_ms - shock_time_ms
+            deltas.append(dt)
+            print("\rdt=%0.1f ms" % dt)
+        print('Median tap-to-audio latency: %0.1f ms' % numpy.median(deltas))
+
+
+def run_tap_blink_test(args):
+    print('Starting tap-to-blink latency test')
+    with Walt(args.serial) as walt:
+        walt.sndrcv(Walt.CMD_RESET)
+        t_zero = walt.zero_clock()
+        if t_zero < 0:
+            print('Error: Couldn\'t zero clock, exiting')
+            sys.exit(1)
+
+        walt.sndrcv(Walt.CMD_GSHOCK)
+        walt.sndrcv(Walt.CMD_AUTO_SCREEN_ON)
+        deltas = []
+        while len(deltas) < args.n:
+            trigger_line = walt.readline()
+            blink_time_seconds, val = walt.parse_trigger(trigger_line)
+            blink_time_ms = blink_time_seconds * 1e3
+            shock_time_ms = walt.read_shock_time() / 1e3
+            if shock_time_ms == 0:
+                print("No shock detected, skipping this event")
+                continue
+            dt = blink_time_ms - shock_time_ms
+            deltas.append(dt)
+            print("dt=%0.1f ms" % dt)
+        print('Median tap-to-blink latency: %0.1f ms' % numpy.median(deltas))
+
+
 def run_tap_latency_test(args):
 
     if not args.input:
@@ -465,10 +527,9 @@ def run_tap_latency_test(args):
 
     with Walt(args.serial) as walt:
         walt.sndrcv(Walt.CMD_RESET)
-        tstart = time.time()
         t_zero = walt.zero_clock()
         if t_zero < 0:
-            print('Error: Couldn\'t zero clock, exitting')
+            print('Error: Couldn\'t zero clock, exiting')
             sys.exit(1)
 
         # Fire up the evtest process
@@ -511,9 +572,9 @@ def run_tap_latency_test(args):
     print('dt_up = ' + array2str(dt_up))
 
     median_down_ms = numpy.median(dt_down)
-    meidan_up_ms = numpy.median(dt_up)
+    median_up_ms = numpy.median(dt_up)
 
-    print('Median latency, down: %0.1f, up: %0.1f' % (median_down_ms, meidan_up_ms))
+    print('Median latency, down: %0.1f, up: %0.1f' % (median_down_ms, median_up_ms))
 
 
 def run_walt_sanity_test(args):
@@ -714,6 +775,10 @@ def main(argv=sys.argv[1:]):
         run_screen_curve(args)
     elif args.type == 'bridge':
         run_tcp_bridge(args)
+    elif args.type == 'tapaudio':
+        run_tap_audio_test(args)
+    elif args.type == 'tapblink':
+        run_tap_blink_test(args)
     else:
         print('Unknown test type: "%s"' % args.type)
 


### PR DESCRIPTION
Test any device without having the WALT app installed. Connect WALT to your workstation, and use pywalt to run end-to-end tests (ex. `./walt -t tapaudio`). 

For the tapblink test, the device under test must be able to flip the screen between black/white when tapped. You can use [this site](http://crostouchlatency.appspot.com/tap) or [this site](sahiljain.ca/blink).

For the tapaudio, the device under test must be able to play a sound when tapped. You can use a trumpet app such as [this one](https://play.google.com/store/apps/details?id=com.snowysapps.trumpet2.android).